### PR TITLE
fix "-2" in provenance

### DIFF
--- a/2022/2022_automatic_evaluation_topics_flattened_duplicated_v1.0.json
+++ b/2022/2022_automatic_evaluation_topics_flattened_duplicated_v1.0.json
@@ -2833,8 +2833,7 @@
                 "response": "For example,  Author of the book “algorithms of oppression”, Safiya U. Noble was looking for websites to share with her stepdaughter and nieces. She searched \"black girls\" on Google, expecting to be directed to educational sites, historical information, or pop culture sites for young people. Instead, the first hit was the site HotBlackPussy.com. The first page was filled with similar results. According to Google in 2010, \"black girls\" were defined not by history, interests, or aspirations. They were defined as porn. What accounts for such racist, sexist search results? Most people tend to attribute Google failures or glitches like this to public search patterns; search engines return porn for \"black girls\" because those are the sites that people click on most.",
                 "provenance": [
                     "MARCO_48_119371286-1",
-                    "MARCO_16_1884092099",
-                    "-2"
+                    "MARCO_16_1884092099-2"
                 ],
                 "automatic_rewritten_utterance": "How does search algorithms perpetuate oppression and discriminate against People of Color?"
             },

--- a/2022/2022_automatic_evaluation_topics_tree_v1.0.json
+++ b/2022/2022_automatic_evaluation_topics_tree_v1.0.json
@@ -3275,8 +3275,7 @@
                 "response": "For example,  Author of the book “algorithms of oppression”, Safiya U. Noble was looking for websites to share with her stepdaughter and nieces. She searched \"black girls\" on Google, expecting to be directed to educational sites, historical information, or pop culture sites for young people. Instead, the first hit was the site HotBlackPussy.com. The first page was filled with similar results. According to Google in 2010, \"black girls\" were defined not by history, interests, or aspirations. They were defined as porn. What accounts for such racist, sexist search results? Most people tend to attribute Google failures or glitches like this to public search patterns; search engines return porn for \"black girls\" because those are the sites that people click on most.",
                 "provenance": [
                     "MARCO_48_119371286-1",
-                    "MARCO_16_1884092099",
-                    "-2"
+                    "MARCO_16_1884092099-2"
                 ]
             },
             {

--- a/2022/2022_evaluation_topics_flattened_duplicated_v1.0.json
+++ b/2022/2022_evaluation_topics_flattened_duplicated_v1.0.json
@@ -2834,8 +2834,7 @@
                 "response": "For example,  Author of the book “algorithms of oppression”, Safiya U. Noble was looking for websites to share with her stepdaughter and nieces. She searched \"black girls\" on Google, expecting to be directed to educational sites, historical information, or pop culture sites for young people. Instead, the first hit was the site HotBlackPussy.com. The first page was filled with similar results. According to Google in 2010, \"black girls\" were defined not by history, interests, or aspirations. They were defined as porn. What accounts for such racist, sexist search results? Most people tend to attribute Google failures or glitches like this to public search patterns; search engines return porn for \"black girls\" because those are the sites that people click on most.",
                 "provenance": [
                     "MARCO_48_119371286-1",
-                    "MARCO_16_1884092099",
-                    "-2"
+                    "MARCO_16_1884092099-2"
                 ]
             },
             {

--- a/2022/2022_evaluation_topics_tree_v1.0.json
+++ b/2022/2022_evaluation_topics_tree_v1.0.json
@@ -3275,8 +3275,7 @@
                 "response": "For example,  Author of the book “algorithms of oppression”, Safiya U. Noble was looking for websites to share with her stepdaughter and nieces. She searched \"black girls\" on Google, expecting to be directed to educational sites, historical information, or pop culture sites for young people. Instead, the first hit was the site HotBlackPussy.com. The first page was filled with similar results. According to Google in 2010, \"black girls\" were defined not by history, interests, or aspirations. They were defined as porn. What accounts for such racist, sexist search results? Most people tend to attribute Google failures or glitches like this to public search patterns; search engines return porn for \"black girls\" because those are the sites that people click on most.",
                 "provenance": [
                     "MARCO_48_119371286-1",
-                    "MARCO_16_1884092099",
-                    "-2"
+                    "MARCO_16_1884092099-2"
                 ]
             },
             {


### PR DESCRIPTION
I spotted one case where there is an MS MARCO id broken into two within an array. I did not perform further checks, but it seems likely to me that there was just a linebreak added by accident in some point in the pipeline.